### PR TITLE
Add cmn sub cdte

### DIFF
--- a/collections/CdTeCollection.py
+++ b/collections/CdTeCollection.py
@@ -397,9 +397,12 @@ class CdTeCollection:
         E.g., the cmn are all 'per ASIC' (so 2 for Al for every event) 
         but want structure to give the common mode for each ADC value.
         """
-        ptcmn = self.event_dataframe['cmn_pt']
-        num = len(ptcmn[:,0])
-        return np.concatenate((np.resize(ptcmn[:,0],(64,num)),np.resize(ptcmn[:,1],(64,num))), axis=0).T
+        asic0 = np.nonzero(self.event_dataframe['index_pt']<64)
+        asic1 = np.nonzero((self.event_dataframe['index_pt']>=64) and (self.event_dataframe['index_pt']<128))
+        common_modes = np.zeros(np.shape(self.event_dataframe['adc_cmn_pt']))
+        common_modes[asic0] = self.event_dataframe['cmn_pt'][0]
+        common_modes[asic1] = self.event_dataframe['cmn_pt'][1]
+        return common_modes
     
     def get_al_cmn(self):
         """ 
@@ -409,9 +412,12 @@ class CdTeCollection:
         E.g., the cmn are all 'per ASIC' (so 2 for Al for every event) 
         but want structure to give the common mode for each ADC value.
         """
-        alcmn = self.event_dataframe['cmn_al']
-        num = len(alcmn[:,0])
-        return np.concatenate((np.resize(alcmn[:,0],(64,num)),np.resize(alcmn[:,1],(64,num))), axis=0).T
+        asic0 = np.nonzero(self.event_dataframe['index_al']<64)
+        asic1 = np.nonzero((self.event_dataframe['index_al']>=64) and (self.event_dataframe['index_al']<128))
+        common_modes = np.zeros(np.shape(self.event_dataframe['adc_cmn_al']))
+        common_modes[asic0] = self.event_dataframe['cmn_al'][0]
+        common_modes[asic1] = self.event_dataframe['cmn_al'][1]
+        return common_modes
 
     def add_cmn(self, new_events_index):
         """ 
@@ -466,7 +472,11 @@ class CdTeCollection:
             pt_adc = np.ndarray.flatten(self.event_dataframe['adc_cmn_pt'][new])
             al_adc = np.ndarray.flatten(self.event_dataframe['adc_cmn_al'][new])
         else:
-            pt_adc, al_adc = self.add_cmn(new)
+            try:
+                pt_adc = np.ndarray.flatten(self.event_dataframe['adc_pt'][new])
+                al_adc = np.ndarray.flatten(self.event_dataframe['adc_al'][new])
+            except AttributeError:
+                pt_adc, al_adc = self.add_cmn(new)
         all_adc = np.concatenate((pt_adc, al_adc))
 
         #**********************************************************************

--- a/collections/CdTeCollection.py
+++ b/collections/CdTeCollection.py
@@ -398,10 +398,11 @@ class CdTeCollection:
         but want structure to give the common mode for each ADC value.
         """
         asic0 = np.nonzero(self.event_dataframe['index_pt']<64)
-        asic1 = np.nonzero((self.event_dataframe['index_pt']>=64) and (self.event_dataframe['index_pt']<128))
+        asic1 = np.nonzero((self.event_dataframe['index_pt']>=64) & (self.event_dataframe['index_pt']<128))
         common_modes = np.zeros(np.shape(self.event_dataframe['adc_cmn_pt']))
-        common_modes[asic0] = self.event_dataframe['cmn_pt'][0]
-        common_modes[asic1] = self.event_dataframe['cmn_pt'][1]
+        # now look at the asic common mode values and then extract the indices you need
+        common_modes[asic0] = self.event_dataframe['cmn_pt'][:,0][asic0[0]]
+        common_modes[asic1] = self.event_dataframe['cmn_pt'][:,1][asic1[0]]
         return common_modes
     
     def get_al_cmn(self):
@@ -413,10 +414,10 @@ class CdTeCollection:
         but want structure to give the common mode for each ADC value.
         """
         asic0 = np.nonzero(self.event_dataframe['index_al']<64)
-        asic1 = np.nonzero((self.event_dataframe['index_al']>=64) and (self.event_dataframe['index_al']<128))
+        asic1 = np.nonzero((self.event_dataframe['index_al']>=64) & (self.event_dataframe['index_al']<128))
         common_modes = np.zeros(np.shape(self.event_dataframe['adc_cmn_al']))
-        common_modes[asic0] = self.event_dataframe['cmn_al'][0]
-        common_modes[asic1] = self.event_dataframe['cmn_al'][1]
+        common_modes[asic0] = self.event_dataframe['cmn_al'][:,0][asic0[0]]
+        common_modes[asic1] = self.event_dataframe['cmn_al'][:,1][asic1[0]]
         return common_modes
 
     def add_cmn(self, new_events_index):
@@ -472,11 +473,10 @@ class CdTeCollection:
             pt_adc = np.ndarray.flatten(self.event_dataframe['adc_cmn_pt'][new])
             al_adc = np.ndarray.flatten(self.event_dataframe['adc_cmn_al'][new])
         else:
-            try:
-                pt_adc = np.ndarray.flatten(self.event_dataframe['adc_pt'][new])
-                al_adc = np.ndarray.flatten(self.event_dataframe['adc_al'][new])
-            except AttributeError:
-                pt_adc, al_adc = self.add_cmn(new)
+            pt_adc = np.ndarray.flatten(self.event_dataframe['adc_pt'][new])
+            al_adc = np.ndarray.flatten(self.event_dataframe['adc_al'][new])
+            # used to be:
+            # pt_adc, al_adc = self.add_cmn(new)
         all_adc = np.concatenate((pt_adc, al_adc))
 
         #**********************************************************************


### PR DESCRIPTION
There was a bug reported introduced from new parser behaviour a while ago where the spectrogram created by adding in the CdTe common modes was not being done correctly. This PR addresses this.

The issue rarely caused anything strange, however, the following pattern has been spotted recently,
<img width="550" alt="Screenshot 2025-06-03 at 2 09 34 pm" src="https://github.com/user-attachments/assets/b0019bcc-1eac-4a71-b6ff-632bcf9d5cec" />
where the pedestal for the first ASIC on the Al-side was showing strange behaviour (showing really low ADC values).

Previously, PR #9 made it so that CdTe data parser returns the original ADC values and not just the common mode subtracted ones. This PR replaces the code that constructed the spectrogram plot by adding the common mode back in with the new fields added in PR #9. This can be seen in the `add_cmn` method below.

Additionally, to avoid anything breaking that uses the rest of the code, the older methods used to add in the common modes originally have been updated to perform the correct calculations (see `get_pt_cmn` and `get_al_cmn`).

The spectrogram created after these updates now becomes
![Screenshot 2025-06-03 at 2 06 28 pm](https://github.com/user-attachments/assets/ae04abea-90a1-46e5-a9f6-d571bb59063e)

(The detector/data used to verify this was a measurement using the new CdTe5 while observing an Fe55 source.)

@NShunsaku , this should now be fixed. @yixianz, @pet00184, @mstores98, please feel free to have a look and offer comments.