### PR TITLE
Add Timepix event data and pcap health

### DIFF
--- a/parsers/Timepixparser.py
+++ b/parsers/Timepixparser.py
@@ -186,6 +186,7 @@ def unpack_photon(data_bytes):
     return x, y, tot, spare
 
 def timepix_pc_parser(packet_bytes):
+    """ parse a single frame (1440 bytes) of Timepix photon-counting data and output a np structured array."""
     if len(packet_bytes) != NUM_PHOTONS * 4:
         raise ValueError("Packet size is " + str(len(packet_bytes)) + ", not 1440 bytes")
     xs, ys, tots, spares = [], [], [], []
@@ -227,7 +228,7 @@ def timepix_pcap_parser(packet_bytes):
 ########################################################
 
 # test from file
-def timepix_parser_test(path:str):
+def timepix_hk_parser_test(path:str):
     # file is "timepix_fake_log.txt"
     with open(path,'rb') as f: 
         data = f.read()
@@ -269,7 +270,7 @@ def timepix_parser_test(path:str):
     assert timepix_data["flags"]==flags_set, "Flags does not match."
     print("Timepix test passed.")
 
-def timepix_parsers_check(path:str):
+def timepix_pc_parser_check(path:str):
     """ A visual check of confirm the timepix_pc.log file """
     with open(path, 'rb') as pc_f:
         pc_d = pc_f.read()
@@ -294,6 +295,14 @@ def timepix_parsers_check(path:str):
         bar.ax.set_title('ToT')
         plt.show()
 
+def timepix_pcap_parser_check(path:str):
+    with open(path, 'rb') as pc_f:
+        pc_d = pc_f.read()
+        # select only the first frame (8 bytes) of data for printing:
+        these_pcaps = pc_d[6:6+NUM_PCAPS*2]
+        pcaps = timepix_pcap_parser(these_pcaps)
+        print("pcap sizes: ", pcaps)
+
 
 
 if __name__=="__main__":
@@ -307,9 +316,11 @@ if __name__=="__main__":
 
     # Event data:
     pc_path = os.path.join(sys.argv[1], pc_name)
+    pcap_path = os.path.join(sys.argv[1], pcap_name)
     hk_path = os.path.join(sys.argv[1], hk_name)
 
-    timepix_parser_test(hk_path)
-    timepix_parsers_check(pc_path)
+    timepix_hk_parser_test(hk_path)
+    timepix_pcap_parser_check(pcap_path)
+    timepix_pc_parser_check(pc_path)
 
     # todo: include pcap test.


### PR DESCRIPTION
> [!NOTE]
> Work in progress. Don't merge yet, just want to start sharing code.

@KriSun95 @savsky95

### Overview
Timepix is adding two new telemetry products:
1. Photon event lists.
2. PCAP file info (additional health status information about the Timepix system).

#### Photon event lists
These will be saved by the GSE to a file named `timepix_pc.log`, similar to the photon counting data from CMOS or CdTe. Each raw frame contains 360 events, each event is 4 bytes wide, and includes an x pixel (0-511), y pixel (0-511), and Time over Threshold (ToT) value (0-1023).

A single frame of Timepix event data is 1440 bytes wide. This PR adds the function `timepix_pc_parser(packet_bytes)` to `parsers/Timepixparser.py`. This function ingests one frame (as a `bytes`-like object) and returns a Numpy structured array. The structured array has these fields:

| Field | `dtype` | Description |
|-------|---------|-------------|
|`['x']`|`np.uint16`| The x position pixel of the event. |
|`['y']`|`np.uint16`| The y position pixel of the event. |
|`['tot']`|`np.uint16`| The ToT value of the event. |
|`['spare']`|`np.uint16`| Don't know what this is, don't think we need to use it. |

I include a function `timepix_pc_parser_check(filename)` that will produce scatterplot an image of the first frame in the `filename` you give it.

#### PCAP health info
These will be saved by the GSE to a file named `timepix_pcap.log`. Each frame is 8 bytes wide. This PR adds the function `timepix_pcap_parser(packet_bytes)` to `parsers/Timepixparser.py`. This function ingests one frame (as a `bytes`-like object) and returns a Numpy array containing four PCAP file sizes. 

I haven't yet written a test for this parser, and I do not have a raw log file sample for this data.

### Testing
I've changed the test implementation in the `Timepixparser.py` file. Now you should pass in a path to a folder containing the raw log files:
```bash
python Timepixparser.py path/to/folder/of/logs/
```

I'll send a sample folder like that in Slack.

### Changes in this PR
- [x] Add a parser for Timepix event data.
- [x] Add a test for Timepix event data parsing. Maybe this is not a real test as implemented. I just display an figure of the event data for visual check.
- [x] Feed sample PCAP health data through the Formatter and log it in GSE.
- [x] Write a test of `timepix_pcap_parser()`.

### Next steps
@KriSun95, can you take a look at the output of `timepix_pc_parser()` (the structured array for the event data) and work on image display when you get the chance?